### PR TITLE
Update Slack webhook secret name

### DIFF
--- a/.github/workflows/workflow-monitor.yml
+++ b/.github/workflows/workflow-monitor.yml
@@ -90,5 +90,5 @@ jobs:
               ]
             }
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_URL: ${{ secrets.TECH_ALERTS_SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK 


### PR DESCRIPTION
Updates the Slack webhook secret name to use TECH_ALERTS_SLACK_WEBHOOK_URL organization secret.

## Changes
- Updates webhook secret reference from SLACK_WEBHOOK_URL to TECH_ALERTS_SLACK_WEBHOOK_URL
- Uses organization-level secret for consistency
- No functional changes