### PR TITLE
refactor(docusaurus): consume OpenAPI specs desde archivos locales

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -64,6 +64,19 @@ jobs:
       - name: Install dependencies
         run: yarn
 
+      - name: Download OpenAPI specs
+        run: |
+          mkdir -p static/openapi/backoffice
+
+          curl --fail --retry 5 --retry-delay 5 https://api.stg.belo.app/v1/docs/json -o static/openapi/v1.json
+          curl --fail --retry 5 --retry-delay 5 https://api.stg.belo.app/v2/docs/json -o static/openapi/v2.json
+          curl --fail --retry 5 --retry-delay 5 https://api.stg.belo.app/payment/docs/json -o static/openapi/payment.json
+          curl --fail --retry 5 --retry-delay 5 https://api.stg.belo.app/v1/docs/json -o static/openapi/_v3.json
+          curl --fail --retry 5 --retry-delay 5 https://frigg.stg.belo.link/v1/docs/json -o static/openapi/crypto.json
+          curl --fail --retry 5 --retry-delay 5 https://api.stg.baldr.app/api/docs/json -o static/openapi/backoffice/api.json
+          curl --fail --retry 5 --retry-delay 5 https://api.stg.baldr.app/dashboard/docs/json -o static/openapi/backoffice/dashboard.json
+          curl --fail --retry 5 --retry-delay 5 https://api.stg.baldr.app/public/docs/json -o static/openapi/backoffice/public.json
+      
       - name: Build
         run: yarn build
 

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -39,8 +39,12 @@ jobs:
           --name-only ${{ github.event.before }} ${{ github.sha }} | grep -E '^(docker/|packages/|.github/workflows/continuous-deployment.yml)' | &> /dev/null \
           && echo 'true' ||  echo 'false')" >> $GITHUB_OUTPUT
 
+
+    
+
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     needs: check-changes
     outputs:
       DOCKER_IMAGE: ${{ steps.build-image.outputs.docker-image }}

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -68,19 +68,6 @@ jobs:
       - name: Install dependencies
         run: yarn
 
-      - name: Download OpenAPI specs
-        run: |
-          mkdir -p static/openapi/backoffice
-
-          curl --fail --retry 5 --retry-delay 5 https://api.stg.belo.app/v1/docs/json -o static/openapi/v1.json
-          curl --fail --retry 5 --retry-delay 5 https://api.stg.belo.app/v2/docs/json -o static/openapi/v2.json
-          curl --fail --retry 5 --retry-delay 5 https://api.stg.belo.app/payment/docs/json -o static/openapi/payment.json
-          curl --fail --retry 5 --retry-delay 5 https://api.stg.belo.app/v1/docs/json -o static/openapi/_v3.json
-          curl --fail --retry 5 --retry-delay 5 https://frigg.stg.belo.link/v1/docs/json -o static/openapi/crypto.json
-          curl --fail --retry 5 --retry-delay 5 https://api.stg.baldr.app/api/docs/json -o static/openapi/backoffice/api.json
-          curl --fail --retry 5 --retry-delay 5 https://api.stg.baldr.app/dashboard/docs/json -o static/openapi/backoffice/dashboard.json
-          curl --fail --retry 5 --retry-delay 5 https://api.stg.baldr.app/public/docs/json -o static/openapi/backoffice/public.json
-      
       - name: Build
         run: yarn build
 

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# OpenAPI specs descargados dinámicamente
+/static/openapi/*.json
+/static/openapi/backoffice/*.json

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -116,37 +116,35 @@ const config = {
       {
         specs: [
           {
-            spec: isProduction
-              ? "https://api.stg.belo.app/v1/docs/json"
-              : "http://localhost:3000/v1/docs/json",
+            spec: "static/openapi/v1.json",
             route: "/v1/",
           },
           {
-            spec: "https://api.stg.belo.app/v2/docs/json",
+            spec: "static/openapi/v2.json",
             route: "/v2/",
           },
           {
-            spec: "https://api.stg.belo.app/payment/docs/json",
+            spec: "static/openapi/payment.json",
             route: "/payment/",
           },
           {
-            spec: "https://api.stg.belo.app/v1/docs/json",
+            spec: "static/openapi/_v3.json",
             route: "/_v3/",
           },
           {
-            spec: "https://frigg.stg.belo.link/v1/docs/json",
+            spec: "static/openapi/crypto.json",
             route: "/crypto/",
           },
           {
-            spec: "https://api.stg.baldr.app/api/docs/json",
+            spec: "static/openapi/backoffice/api.json",
             route: "/backoffice/api",
           },
           {
-            spec: "https://api.stg.baldr.app/dashboard/docs/json",
+            spec: "static/openapi/backoffice/dashboard.json",
             route: "/backoffice/dashboard",
           },
           {
-            spec: "https://api.stg.baldr.app/public/docs/json",
+            spec: "static/openapi/backoffice/public.json",
             route: "/backoffice/public",
           },
         ],

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "docusaurus": "docusaurus",
     "dev": "docusaurus start -p 9000",
-    "build": "docusaurus build",
+    "fetch-specs": "bash scripts/fetch-openapi-specs.sh",
+    "build": "yarn fetch-specs && docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",

--- a/scripts/fetch-openapi-specs.sh
+++ b/scripts/fetch-openapi-specs.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "📥 Descargando OpenAPI specs..."
+mkdir -p static/openapi/backoffice
+
+curl --fail --retry 5 --retry-delay 5 https://api.stg.belo.app/v1/docs/json -o static/openapi/v1.json
+curl --fail --retry 5 --retry-delay 5 https://api.stg.belo.app/v2/docs/json -o static/openapi/v2.json
+curl --fail --retry 5 --retry-delay 5 https://api.stg.belo.app/payment/docs/json -o static/openapi/payment.json
+curl --fail --retry 5 --retry-delay 5 https://api.stg.belo.app/v1/docs/json -o static/openapi/_v3.json
+curl --fail --retry 5 --retry-delay 5 https://frigg.stg.belo.link/v1/docs/json -o static/openapi/crypto.json
+curl --fail --retry 5 --retry-delay 5 https://api.stg.baldr.app/api/docs/json -o static/openapi/backoffice/api.json
+curl --fail --retry 5 --retry-delay 5 https://api.stg.baldr.app/dashboard/docs/json -o static/openapi/backoffice/dashboard.json
+curl --fail --retry 5 --retry-delay 5 https://api.stg.baldr.app/public/docs/json -o static/openapi/backoffice/public.json
+
+echo "✅ Specs descargados correctamente."


### PR DESCRIPTION
Se reemplazaron las URLs externas de los specs OpenAPI por rutas locales en static/openapi/, mejorando la estabilidad del build en CI/CD.

Se agregó soporte a estructura jerárquica para agrupar specs por contexto (ej: backoffice). Esto permite reproducibilidad del sitio sin depender de servicios en stg.

El pipeline ahora descarga los JSON antes del build.

BREAKING CHANGE: los specs deben estar presentes localmente para poder ejecutar yarn build.